### PR TITLE
Add various services

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ In the future someone will be capable of accessing all that information and I as
    * [Metager](https://metager.de/)
    * [StartPage](https://www.startpage.com/)
    * [Ecosia](https://www.ecosia.org/)
+   * [SearXNG](https://github.com/searxng/searxng)
 
 #### **Youtube**
   

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ In the future someone will be capable of accessing all that information and I as
   * [Brave](https://brave.com/)
   * [Gnu IceCat](https://www.gnu.org/software/gnuzilla/)
   * [Waterfox](https://www.waterfox.net/)
+  * [Mullvad Browser](https://mullvad.net/en/browser)
   
   
 #### **Google Home**

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ In the future someone will be capable of accessing all that information and I as
   * [Fathom Analytics](https://usefathom.com/)
   * [AT Internet](https://www.atinternet.com/en/)
   * [Clicky](https://clicky.com/)
+  * [Umami](https://umami.is/)
   
 
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ In the future someone will be capable of accessing all that information and I as
   * [Plasma Mobile](https://www.plasma-mobile.org/)
   * [Sailfish OS](https://sailfishos.org/)
   * [CalyxOS](https://calyxos.org)
+  * [LineageOS](https://lineageos.org/)
   
   
 #### **Google Calendar**
@@ -141,6 +142,8 @@ In the future someone will be capable of accessing all that information and I as
   * [Fathom Analytics](https://usefathom.com/)
   * [AT Internet](https://www.atinternet.com/en/)
   * [Clicky](https://clicky.com/)
+  
+
 
 
 #### **Google Maps**

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ In the future someone will be capable of accessing all that information and I as
   * [Bitchute](https://www.bitchute.com/)
   * [Bit.tube](https://bit.tube/)
   * [NewPipe](https://newpipe.net/)
+  * [invidious](https://github.com/iv-org/invidious)
   
   
 #### **Gmail**

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ In the future someone will be capable of accessing all that information and I as
   * [Njalla](https://njal.la/)
   * [Namecheap](https://www.namecheap.com/)
   * [OrangeWebsite](https://www.orangewebsite.com/)
+  * [Porkbun](https://porkbun.com/)
 
 
 


### PR DESCRIPTION
Adds the following

- LinageOS to Android alternatives
- SearXNG to Google Search alternatives
- Invidious to Youtube alternatives
- Mullvad browser to Chrome alternatives
- Umami to Google Analytics alternatives
- Porkbun to Google Domains alternatives
For the last commit I should note Google has sold their domains business to squarespace, so we could outright remove Google Domains or possibly rename the field if we wish to maintain a list still.